### PR TITLE
Add postBuild and Binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jupyterlab Extensions by Examples
 
 ![Github Actions Status](https://github.com/jtpio/jupyterlab-extension-examples/workflows/CI/badge.svg)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/jupyterlab-extension-examples/master?urlpath=lab)
 
 ## TL;DR
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,5 @@
+jlpm
+jlpm build-ext
+jlpm link-ext
+jlpm build-jlab
+


### PR DESCRIPTION
Fixes #6.

The Binder link points to the `master` branch so it will always reflect the latest state of the repo.