### PR TITLE
Enhance Signal example with argument

### DIFF
--- a/basics/signals/README.md
+++ b/basics/signals/README.md
@@ -171,7 +171,7 @@ It registers the `_logMessage` function which is triggered when the signal is em
 
 > From the official [JupyterLab Documentation](https://jupyterlab.readthedocs.io/en/stable/developer/patterns.html#signals):
 > Wherever possible as signal connection should be made with the pattern `.connect(this._onFoo, this)`.
-> Providing the this context enables the connection to be properly cleared by clearSignalData(this).
+> Providing the `this` context enables the connection to be properly cleared by `clearSignalData(this)`.
 > Using a private method avoids allocating a closure for each connection.
 
 The `_logMessage` function receives as parameters the emitter (of type `ButtonWidgeet`)

--- a/basics/signals/README.md
+++ b/basics/signals/README.md
@@ -114,7 +114,7 @@ protected _count: ICount = {
 private _stateChanged = new Signal<this, ICount>(this);
 ```
 
-A signal object can be triggered and then emits an actual message.
+A signal object can be triggered and then emits an actual signal.
 
 Other Widgets can subscribe to such a signal and react when a message is
 emitted.

--- a/basics/signals/README.md
+++ b/basics/signals/README.md
@@ -30,7 +30,7 @@ some visual elements such as a button, defines a `_stateChanged` signal:
 private _stateChanged = new Signal<this, ICount>(this);
 ```
 
-That private signal is exposed to other widgeets via a public accessor method.
+That private signal is exposed to other widgets via a public accessor method.
 
 ```ts
 // src/button.tsx#L15-L17

--- a/basics/signals/README.md
+++ b/basics/signals/README.md
@@ -57,7 +57,7 @@ The `_logMessage` is executed when the signal is triggered from the first widget
 this._stateChanged.emit(this._count);
 ```
 
-Let's see how the implementations details.
+Let's look at the implementations details.
 
 ## A simple React Button
 

--- a/basics/signals/README.md
+++ b/basics/signals/README.md
@@ -10,30 +10,32 @@
 
 ## Lumino Signaling 101
 
-In this extension, a simple button will be added to print something to the console.
 Communication between different components of JupyterLab is a key ingredient in building an
 extension.
 
+In this extension, a simple button will be added to print something to the console.
+
 JupyterLab's Lumino engine uses the `ISignal` interface and the
 `Signal` class that implements this interface for communication
-([documentation](https://jupyterlab.github.io/lumino/api/signaling/globals.html)).
+(read more on the [documentation](https://jupyterlab.github.io/lumino/api/signaling/globals.html) page).
 
 The basic concept is as follows:
 
 First, a widget (`button.ts`), in this case the one that contains
-some visual elements such as a button, defines a signal and exposes it to other
-widgets, as this `_stateChanged` signal:
+some visual elements such as a button, defines a `_stateChanged` signal:
 
 ```ts
-// src/button.tsx#L24-L24
+// src/button.tsx#L36-L36
 
-private _stateChanged = new Signal<ButtonWidget, void>(this);
+private _stateChanged = new Signal<this, ICount>(this);
 ```
 
-```ts
-// src/button.tsx#L6-L8
+That private signal is exposed to other widgeets via a public accessor method.
 
-get stateChanged(): ISignal<ButtonWidget, void> {
+```ts
+// src/button.tsx#L15-L17
+
+public get stateChanged(): ISignal<this, ICount> {
   return this._stateChanged;
 }
 ```
@@ -42,22 +44,20 @@ Another widget, in this case the panel (`panel.ts`) that boxes several different
 subscribes to the `stateChanged` signal and links some function to it:
 
 ```ts
-// src/panel.ts#L22-L24
+// src/panel.ts#L22-L22
 
-this._widget.stateChanged.connect(() => {
-  console.log('Button is clicked.');
-  window.alert('Button is clicked.');
+this._widget.stateChanged.connect(this._logMessage, this);
 ```
 
-The function is executed when the signal is triggered from the first widget with:
+The `_logMessage` is executed when the signal is triggered from the first widget with:
 
 ```ts
-// src/button.tsx#L16-L16
+// src/button.tsx#L28-L28
 
-this._stateChanged.emit(void 0);
+this._stateChanged.emit(this._count);
 ```
 
-Let's see how you can implement this...
+Let's see how the implementations details.
 
 ## A simple React Button
 
@@ -66,78 +66,134 @@ HTML-like syntax with the tag notation `<>`to represent some visual elements
 (note that you have to add a line: `"jsx": "react",` to the
 `tsconfig.json` file). This is a special syntax used by [React](https://reactjs.org/tutorial/tutorial.html).
 
-`button.tsx` contains one major class `ButtonWidget` that extends the
-`ReactWidget` class provided by JupyterLab. `ReactWidget` defines a
-`render()` method that defines some React elements such as a button. This
-is the recommended way to include React component inside the JupyterLab widget
-based UI.
+You can also try the [React Widget example](./../../react/react-widget) for more details.
 
-`ButtonWidget` further contains a private variable `_stateChanged` of type
-`Signal`. A signal object can be triggered and then emits an actual message.
-Other Widgets can subscribe to such a signal and react when a message is
-emitted. The button `onClick` event is configured to trigger the
-`stateChanged` signal with `_stateChanged.emit(void 0)`:
+`button.tsx` contains one major class `ButtonWidget` that extends the
+`ReactWidget` class provided by JupyterLab.
+
+`ReactWidget` defines a `render()` method that defines some React elements such as a button.
+This is the recommended way to include React component inside the JupyterLab widget based UI.
 
 ```ts
-// src/button.tsx#L5-L25
+// src/button.tsx#L19-L34
 
-export class ButtonWidget extends ReactWidget {
-  get stateChanged(): ISignal<ButtonWidget, void> {
-    return this._stateChanged;
-  }
-
-  protected render(): React.ReactElement<any> {
-    return (
-      <button
-        key="header-thread"
-        className="jp-example-button"
-        onClick={(): void => {
-          this._stateChanged.emit(void 0);
-        }}
-      >
-        Clickme
-      </button>
-    );
-  }
-
-  private _stateChanged = new Signal<ButtonWidget, void>(this);
+protected render(): React.ReactElement<any> {
+  return (
+    <button
+      key="header-thread"
+      className="jp-example-button"
+      onClick={(): void => {
+        this._count = {
+          clickCount: this._count.clickCount + 1
+        };
+        this._stateChanged.emit(this._count);
+      }}
+    >
+      Clickme
+    </button>
+  );
 }
+```
+
+`ButtonWidget` also contain a private attribute `_count` of type `ICount`.
+
+```ts
+// src/button.tsx#L11-L13
+
+protected _count: ICount = {
+  clickCount: 0
+};
+```
+
+`ButtonWidget` further contains a private variable `_stateChanged` of type
+`Signal`.
+
+```ts
+// src/button.tsx#L36-L36
+
+private _stateChanged = new Signal<this, ICount>(this);
+```
+
+A signal object can be triggered and then emits an actual message.
+
+Other Widgets can subscribe to such a signal and react when a message is
+emitted.
+
+The button `onClick` event will increment the `_count`
+private attribute and will trigger the `_stateChanged` signal passing
+the `_count` variable.
+
+```ts
+// src/button.tsx#L24-L29
+
+onClick={(): void => {
+  this._count = {
+    clickCount: this._count.clickCount + 1
+  };
+  this._stateChanged.emit(this._count);
+}}
 ```
 
 ## Subscribing to a Signal
 
 The `panel.ts` class defines an extension panel that displays the
 `ButtonWidget` widget and that subscribes to its `stateChanged` signal.
-
-Subscription to a signal is done using the `connect` method of the
-`stateChanged` attribute. It registers a function (in this case
-`() => { console.log('Button is clicked.'); }` that is triggered when the signal is
-emitted:
+This is done in the constructor.
 
 ```ts
-// src/panel.ts#L12-L29
+// src/panel.ts#L13-L23
 
-export class SignalExamplePanel extends StackedPanel {
-  constructor() {
-    super();
-    this.addClass(PANEL_CLASS);
-    this.id = 'SignalExamplePanel';
-    this.title.label = 'Signal Example View';
-    this.title.closable = true;
+constructor() {
+  super();
+  this.addClass(PANEL_CLASS);
+  this.id = 'SignalExamplePanel';
+  this.title.label = 'Signal Example View';
+  this.title.closable = true;
 
-    this._widget = new ButtonWidget();
-    this.addWidget(this._widget);
-    this._widget.stateChanged.connect(() => {
-      console.log('Button is clicked.');
-      window.alert('Button is clicked.');
-    });
-  }
-
-  private _widget: ButtonWidget;
+  this._widget = new ButtonWidget();
+  this.addWidget(this._widget);
+  this._widget.stateChanged.connect(this._logMessage, this);
 }
 ```
 
-The final extension writes a little `Button is clicked.` text to the browser console and an alert when
-a big red button is clicked.
+Subscription to a signal is done using the `connect` method of the
+`stateChanged` attribute.
 
-It is not very spectacular but the signaling is conceptually important for building extensions.
+```ts
+// src/panel.ts#L22-L22
+
+this._widget.stateChanged.connect(this._logMessage, this);
+```
+
+It registers the `_logMessage` function which is triggered when the signal is emitted.
+
+**Note**
+
+> From the official [JupyterLab Documentation](https://jupyterlab.readthedocs.io/en/stable/developer/patterns.html#signals):
+> Wherever possible as signal connection should be made with the pattern `.connect(this._onFoo, this)`.
+> Providing the this context enables the connection to be properly cleared by clearSignalData(this).
+> Using a private method avoids allocating a closure for each connection.
+
+The `_logMessage` function receives as parameters the emitter (of type `ButtonWidgeet`)
+and the count (of type `ICount`) sent by the signal emitter.
+
+```ts
+// src/panel.ts#L25-L25
+
+private _logMessage(emitter: ButtonWidget, count: ICount) {
+```
+
+In our case, that function writes `Button has been clicked ... times.` text
+to the browser console and in an alert when the big red button is clicked.
+
+```ts
+// src/panel.ts#L25-L29
+
+private _logMessage(emitter: ButtonWidget, count: ICount) {
+  console.log('Hey, a Signal has been received from', emitter);
+  console.log(
+    `The big red button has been clicked ${count.clickCount} times.`
+  );
+```
+
+There it is. Signaling is conceptually important for building extensions.

--- a/basics/signals/README.md
+++ b/basics/signals/README.md
@@ -174,7 +174,7 @@ It registers the `_logMessage` function which is triggered when the signal is em
 > Providing the `this` context enables the connection to be properly cleared by `clearSignalData(this)`.
 > Using a private method avoids allocating a closure for each connection.
 
-The `_logMessage` function receives as parameters the emitter (of type `ButtonWidgeet`)
+The `_logMessage` function receives as parameters the emitter (of type `ButtonWidget`)
 and the count (of type `ICount`) sent by the signal emitter.
 
 ```ts

--- a/basics/signals/src/button.tsx
+++ b/basics/signals/src/button.tsx
@@ -1,9 +1,18 @@
 import { ReactWidget } from '@jupyterlab/apputils';
 import { ISignal, Signal } from '@lumino/signaling';
+
 import * as React from 'react';
 
+export interface ICount {
+  clickCount: number;
+}
+
 export class ButtonWidget extends ReactWidget {
-  get stateChanged(): ISignal<ButtonWidget, void> {
+  protected _count: ICount = {
+    clickCount: 0
+  };
+
+  public get stateChanged(): ISignal<this, ICount> {
     return this._stateChanged;
   }
 
@@ -13,7 +22,10 @@ export class ButtonWidget extends ReactWidget {
         key="header-thread"
         className="jp-example-button"
         onClick={(): void => {
-          this._stateChanged.emit(void 0);
+          this._count = {
+            clickCount: this._count.clickCount + 1
+          };
+          this._stateChanged.emit(this._count);
         }}
       >
         Clickme
@@ -21,5 +33,5 @@ export class ButtonWidget extends ReactWidget {
     );
   }
 
-  private _stateChanged = new Signal<ButtonWidget, void>(this);
+  private _stateChanged = new Signal<this, ICount>(this);
 }

--- a/basics/signals/src/index.ts
+++ b/basics/signals/src/index.ts
@@ -59,9 +59,9 @@ function activate(
   }
 
   // Add menu tab
-  const exampleMenu = new Menu({ commands });
-  exampleMenu.title.label = 'Signal Example';
-  mainMenu.addMenu(exampleMenu);
+  const signalMenu = new Menu({ commands });
+  signalMenu.title.label = 'Signal Example';
+  mainMenu.addMenu(signalMenu);
 
   // Add commands to registry
   commands.addCommand(CommandIDs.create, {
@@ -72,7 +72,7 @@ function activate(
 
   // Add items in command palette and menu
   palette.addItem({ command: CommandIDs.create, category });
-  exampleMenu.addItem({ command: CommandIDs.create });
+  signalMenu.addItem({ command: CommandIDs.create });
 }
 
 export default extension;

--- a/basics/signals/src/panel.ts
+++ b/basics/signals/src/panel.ts
@@ -1,10 +1,10 @@
 import { StackedPanel } from '@lumino/widgets';
 
-import { ButtonWidget } from './button';
+import { ButtonWidget, ICount } from './button';
 /**
  * The class name added to console panels.
  */
-const PANEL_CLASS = 'jp-RovaPanel';
+const PANEL_CLASS = 'jp-tutorial-view';
 
 /**
  * A panel which contains a console and the ability to add other children.
@@ -19,10 +19,17 @@ export class SignalExamplePanel extends StackedPanel {
 
     this._widget = new ButtonWidget();
     this.addWidget(this._widget);
-    this._widget.stateChanged.connect(() => {
-      console.log('Button is clicked.');
-      window.alert('Button is clicked.');
-    });
+    this._widget.stateChanged.connect(this._logMessage, this);
+  }
+
+  private _logMessage(emitter: ButtonWidget, count: ICount) {
+    console.log('Hey, a Signal has been received from', emitter);
+    console.log(
+      `The big red button has been clicked ${count.clickCount} times.`
+    );
+    window.alert(
+      `The big red button has been clicked ${count.clickCount} times.`
+    );
   }
 
   private _widget: ButtonWidget;


### PR DESCRIPTION
This PR does a pass on a Signal example (doc...), align to JupyterLab best practice (use a separated method on connect...) and add a args on the signal.