### PR TITLE
Enable alert on Settings examples and Increment limit setting

### DIFF
--- a/settings/README.md
+++ b/settings/README.md
@@ -231,7 +231,7 @@ Then once the settings are loaded, each setting can be read using
 the `get` method and the _setting id_ (the key defined in the settings
 JSON file).
 
-After getting the setting, you need to require the `composite` attribute
+After getting the setting, you need to access the `composite` attribute
 to get its value and specify the type explicitly.
 
 ```ts

--- a/settings/src/index.ts
+++ b/settings/src/index.ts
@@ -37,9 +37,6 @@ const extension: JupyterFrontEndPlugin<void> = {
       console.log(
         `Settings Example extension: Limit is set to '${limit}' and flag to '${flag}'`
       );
-      //      window.alert(
-      //        `Settings Example extension: Limit is set to '${limit}' and flag to '${flag}'`
-      //      );
     }
 
     // Wait for the application to be restored and
@@ -53,7 +50,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         setting.changed.connect(loadSetting);
 
         commands.addCommand(COMMAND_ID, {
-          label: 'Toggle Flag Setting',
+          label: 'Toggle Flag and Increment Limit',
           isToggled: () => flag,
           execute: () => {
             // Programmatically change a setting
@@ -62,16 +59,29 @@ const extension: JupyterFrontEndPlugin<void> = {
                 `Something went wrong when setting flag.\n${reason}`
               );
             });
+            setting.set('limit', limit + 1).catch(reason => {
+              console.error(
+                `Something went wrong when setting limit.\n${reason}`
+              );
+            });
+            limit = setting.get('limit').composite as number;
+            flag = setting.get('flag').composite as boolean;
+            console.log(
+              `Settings Example extension: Limit is set to '${limit}' and flag to '${flag}'`
+            );
+            window.alert(
+              `Settings Example extension: Limit is set to '${limit}' and flag to '${flag}'`
+            );
           }
         });
 
         // Create a menu
-        const tutorialMenu = new Menu({ commands });
-        tutorialMenu.title.label = 'Settings Example';
-        mainMenu.addMenu(tutorialMenu, { rank: 80 });
+        const settingsMenu = new Menu({ commands });
+        settingsMenu.title.label = 'Settings Example';
+        mainMenu.addMenu(settingsMenu, { rank: 80 });
 
         // Add the command to the menu
-        tutorialMenu.addItem({
+        settingsMenu.addItem({
           command: COMMAND_ID
         });
       })


### PR DESCRIPTION
This PR creates a window.alert on Settings examples when the user changes thee settings via Menu and also increments the `limit` setting.