### PR TITLE
Add rules to conform to style guide

### DIFF
--- a/advanced/kernel-messaging/.eslintrc.js
+++ b/advanced/kernel-messaging/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/advanced/kernel-output/.eslintrc.js
+++ b/advanced/kernel-output/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/advanced/server-extension/.eslintrc.js
+++ b/advanced/server-extension/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/basics/datagrid/.eslintrc.js
+++ b/basics/datagrid/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/basics/hello-world/.eslintrc.js
+++ b/basics/hello-world/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/basics/signals/.eslintrc.js
+++ b/basics/signals/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/command-palette/.eslintrc.js
+++ b/command-palette/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/commands/.eslintrc.js
+++ b/commands/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/launcher/.eslintrc.js
+++ b/launcher/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/main-menu/.eslintrc.js
+++ b/main-menu/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/react/react-widget/.eslintrc.js
+++ b/react/react-widget/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/settings/.eslintrc.js
+++ b/settings/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/state/.eslintrc.js
+++ b/state/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {

--- a/widget-tracker/widgets/.eslintrc.js
+++ b/widget-tracker/widgets/.eslintrc.js
@@ -22,10 +22,17 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property-type': 'off',
     'jsdoc/require-returns-type': 'off',
-    'jsdoc/no-types': 'warn'
+    'jsdoc/no-types': 'warn',
+    'prefer-arrow-callback': 'error'
   },
   settings: {
     jsdoc: {


### PR DESCRIPTION
Following [comment](https://github.com/jtpio/jupyterlab-extension-examples/pull/79#issuecomment-596984442) of @jtpio 

I looked to add rules to enforce guidelines from https://github.com/jupyterlab/jupyterlab/wiki/TypeScript-Style-Guide

Unfortunately, there is less possibilities with eslint compare to tslint especially regarding variable naming convention.

The added rules:
- enforce the use of single quote and backtick only if necessary.
- enforce the use of curly braces in loop, conditions,...